### PR TITLE
afsocket: reuse the last connection to primary

### DIFF
--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -261,6 +261,15 @@ error_reconnect:
   return FALSE;
 }
 
+void
+afsocket_connected_with_fd(AFSocketDestDriver *self, gint fd)
+{
+  afsocket_dd_stop_watches(self);
+  self->fd = fd;
+  afsocket_dd_connected(self);
+}
+
+
 static gboolean
 afsocket_dd_start_connect(AFSocketDestDriver *self)
 {

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -88,5 +88,6 @@ void afsocket_dd_stop_watches(AFSocketDestDriver *self);
 
 gboolean afsocket_dd_init(LogPipe *s);
 void afsocket_dd_free(LogPipe *s);
+void afsocket_connected_with_fd(AFSocketDestDriver *self, gint fd);
 
 #endif


### PR DESCRIPTION
When successfull_probes_required(N), syslog-ng close the Nth succesful
connection and immediately establish a new one to the primary.

We should reuse the last connection.

Other: it is better to use the same socket creation method for the
connection probes as for the 'real' connections.

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>